### PR TITLE
Match service account on 2 or more spaces

### DIFF
--- a/replicated-gcommands/replicated-gcommands.plugin.zsh
+++ b/replicated-gcommands/replicated-gcommands.plugin.zsh
@@ -30,7 +30,7 @@ gcreate() {
   local image_project
   image_project="$(echo "${image}" | awk '{print $2}')"
   local default_service_account
-  default_service_account="$(gcloud iam service-accounts list | grep '\-compute@developer.gserviceaccount.com' | awk 'BEGIN {FS="  "}; {print $2}')"
+  default_service_account="$(gcloud iam service-accounts list | grep '\-compute@developer.gserviceaccount.com' | awk 'BEGIN {FS=" {2,}"}; {print $2}')"
   shift
   local instance_names=("$@")
   if [ -n "${GPREFIX}" ]; then


### PR DESCRIPTION
Service account wasn't working for me, instead of hardcoding 2 spaces I've made it match 2+